### PR TITLE
Add manifest for GitOps workaround

### DIFF
--- a/test/data/manifests/gitops/namespace.yaml
+++ b/test/data/manifests/gitops/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my_namespace
+  labels:
+    argocd.argoproj.io/managed-by: openshift-gitops


### PR DESCRIPTION
GitOps does not automatically create the namespace when a component is created in RHDH. This manifest shows how to create the namespace with the right label so GitOps can sync the application to the namespace.