### PR TITLE
Workaround for GitOps managed namespace

### DIFF
--- a/templates/openshift-gitops/namespace.yaml
+++ b/templates/openshift-gitops/namespace.yaml
@@ -1,0 +1,11 @@
+{{ if .Values.debug.namespaces }}
+{{ range .Values.debug.namespaces }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ . }}
+  labels:
+    argocd.argoproj.io/managed-by: openshift-gitops
+{{ end }}
+{{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -4,6 +4,7 @@
 debug:
   container: false  # Creates a long running container to easily open a terminal for troubleshooting.
   script: false  # Prints commands before executing them.
+  namespaces: [] # List of namespace managed by ArgoCD. Temporary workaround.
 openshift-gitops:
   enabled: true
   channel: gitops-1.11


### PR DESCRIPTION
The DH ArgoCD plugin is currently not able to create namespaces on the cluster.
This change allows a user to declare a number of namespaces in their configuration so they are deployed and ready to be used by DH components.