### PR TITLE
Adding QE owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,3 +3,6 @@ approvers:
 - jduimovich
 - otaviof
 - roming22
+- xinredhat
+- prietyc123
+- flacatus


### PR DESCRIPTION
rh-pre-commit.version: 2.1.0
rh-pre-commit.check-secrets: ENABLED

Openshift release repo autoowner sync removes QE owner from CI (which actually get synced from the repository). Hence adding the owners here.