### PR TITLE
Bug fixes in make.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This helm chart installs and configures the following projects/products :
 
 3. Install/upgrade RHTAP
 
-    `helm upgrade installer rhtap/rhtap --install --create-namespace --namespace rhtap --timeout 10m --values values.yaml`
+    `helm upgrade installer rhtap/rhtap --install --create-namespace --namespace rhtap --timeout 20m --values values.yaml`
 
     Sample output:
     

--- a/bin/make.sh
+++ b/bin/make.sh
@@ -173,9 +173,9 @@ release() {
   Changes from $previous_version:
   $(
     git -C "$HELM_CHART" log \
-      --reverse --format="  - %s" "$previous_version^..$version" \
+      --reverse --format="- %s" "$previous_version^..$version" \
       -- Chart.yaml values.yaml templates |
-      tail -n +2
+      tail -n +3
   )
   "
   git push
@@ -222,6 +222,11 @@ values() {
             PROMPT="0"
           fi
           ;;
+        TPA__*)
+          if [ -z "${TPA__GUAC__PASSWORD:-}" ] && [ "$ENV_VAR" != "TPA__GUAC__PASSWORD" ]; then
+            PROMPT="0"
+          fi
+          ;;
         *) ;;
         esac
         if [ "$PROMPT" == "1" ]; then
@@ -233,7 +238,8 @@ values() {
       echo "$ENV_VAR: OK"
       VALUE=${!ENV_VAR}
     fi
-    echo "export $ENV_VAR='$VALUE'" >>"private.env"
+    # shellcheck disable=SC2001
+    echo "export $ENV_VAR='$(echo "$VALUE" | sed 's: *::')'" >>"private.env"
   done
   # shellcheck source=/dev/null
   source "private.env"


### PR DESCRIPTION
* Increase recommended timeout in README.
* Fix formating issue in helm-repository commit.
* Bypass TPA vars when TPA is not to be installed.
* Remove any leading spaces from vars. Leading spaces have led to failing installs (e.g. GITHUB__APP__PRIVATE_KEY).