### PR TITLE
RHTAPBUGS-1151: ArgoCD Application-Controller Memory Limit

### DIFF
--- a/templates/openshift-gitops/includes/_argocd.tpl
+++ b/templates/openshift-gitops/includes/_argocd.tpl
@@ -119,12 +119,7 @@ spec:
   controller:
     processors: {}
     resources:
-      limits:
-        cpu: '2'
-        memory: 2Gi
-      requests:
-        cpu: 250m
-        memory: 1Gi
+{{ index .Values "openshift-gitops" "argoCD" "controller" "resources" | toYaml | indent 6 }}
   extraConfig:
     accounts.admin: apiKey, login
 {{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -12,9 +12,20 @@ openshift-gitops:
   workload-namespaces:
     - default
   git-token: ${GITOPS__GIT_TOKEN}  # Token to create/push repositories.
+  argoCD:
+    # ArgoCD's application-controller resource limits.
+    controller:
+      resources:
+        limits:
+          cpu: "2"
+          memory: 6Gi
+        requests:
+          cpu: "1"
+          memory: 3Gi
 openshift-pipelines:
   enabled: true
   channel: pipelines-1.14
+
 # Private values
 # You may want to override those variables in another file (e.g. values-private.yaml)
 acs:


### PR DESCRIPTION
Adding more memory to the ArgoCD controller.

/cc @flacatus 