### PR TITLE
Fix DH TLS reconfiguration bug

### DIFF
--- a/bin/make.sh
+++ b/bin/make.sh
@@ -171,7 +171,7 @@ release() {
   git commit -m "Release $version
   
   Changes from $previous_version:
-  $(
+$(
     git -C "$HELM_CHART" log \
       --reverse --format="- %s" "$previous_version^..$version" \
       -- Chart.yaml values.yaml templates |

--- a/templates/developer-hub/includes/configure/_configure_tls.tpl
+++ b/templates/developer-hub/includes/configure/_configure_tls.tpl
@@ -9,40 +9,49 @@ until kubectl get deployment developer-hub -o name >/dev/null ; do
 done
 echo "OK"
 
+DEPLOYMENT="/tmp/deployment.yaml"
+oc get deployment/developer-hub --namespace "rhtap" -o yaml >"$DEPLOYMENT"
+
 echo -n "* Configure TLS:"
-PATCH="/tmp/configure_tls.patch.json"
-cat << EOF >"$PATCH"
-[
-    {
-        "op": "add",
-        "path": "/spec/template/spec/containers/0/env/-",
-        "value": {
-            "name": "NODE_EXTRA_CA_CERTS",
-            "value": "/ingress-cert/ca.crt"
-        }
-    },
-    {
-        "op": "add",
-        "path": "/spec/template/spec/containers/0/volumeMounts/-",
-        "value": {
-            "name": "kube-root-ca",
-            "mountPath": "/ingress-cert"
-        }
-    },
-    {
-        "op": "add",
-        "path": "/spec/template/spec/volumes/-",
-        "value": {
-            "name": "kube-root-ca",
-            "configMap": {
-                "name": "kube-root-ca.crt",
-                "defaultMode": 420
-            }
-        }
-    }
-]
-EOF
+# Update env var.
+if [ "$(yq '.spec.template.spec.containers[0].env[] | select(.name == "NODE_EXTRA_CA_CERTS") | length' "$DEPLOYMENT")" == "2" ]; then
+    YQ_EXPRESSION='
+(
+    .spec.template.spec.containers[].env[] |
+    select(.name == "NODE_EXTRA_CA_CERTS") | .value
+) = "/ingress-cert/ca.crt"
+'
+else
+    YQ_EXPRESSION='.spec.template.spec.containers[0].env += {"name": "NODE_EXTRA_CA_CERTS", "value": "/ingress-cert/ca.crt"}'
+fi
+yq --inplace "$YQ_EXPRESSION" "$DEPLOYMENT"
 echo -n "."
-oc patch deployment/developer-hub --namespace "$NAMESPACE" --type=json --patch-file="$PATCH" >/dev/null
+# Update volume mount
+if [ "$(yq '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "kube-root-ca") | length' "$DEPLOYMENT")" == "2" ]; then
+    YQ_EXPRESSION='
+(
+    .spec.template.spec.containers[].volumeMounts[] |
+    select(.name == "kube-root-ca") | .mountPath
+) = "/ingress-cert"
+'
+else
+    YQ_EXPRESSION='.spec.template.spec.containers[0].volumeMounts += {"name": "kube-root-ca", "mountPath": "/ingress-cert"}'
+fi
+yq --inplace "$YQ_EXPRESSION" "$DEPLOYMENT"
+echo -n "."
+# Update volume
+if [ "$(yq '.spec.template.spec.volumes[] | select(.name == "kube-root-ca") | length' "$DEPLOYMENT")" == "2" ]; then
+    YQ_EXPRESSION='
+(
+    .spec.template.spec.volumes[] |
+    select(.name == "kube-root-ca") | .configMap
+) = {"name": "kube-root-ca.crt", "defaultMode": 420}
+'
+else
+    YQ_EXPRESSION='.spec.template.spec.volumes += {"name": "kube-root-ca", "configMap": {"name": "kube-root-ca.crt", "defaultMode": 420}}'
+fi
+yq --inplace "$YQ_EXPRESSION" "$DEPLOYMENT"
+echo -n "."
+oc apply -f "$DEPLOYMENT" >/dev/null
 echo "OK"
 {{ end }}

--- a/test/data/helm-chart/template.yaml
+++ b/test/data/helm-chart/template.yaml
@@ -585,41 +585,50 @@ spec:
               done
               echo "OK"
               
+              DEPLOYMENT="/tmp/deployment.yaml"
+              oc get deployment/developer-hub --namespace "rhtap" -o yaml >"$DEPLOYMENT"
+              
               echo -n "* Configure TLS:"
-              PATCH="/tmp/configure_tls.patch.json"
-              cat << EOF >"$PATCH"
-              [
-                  {
-                      "op": "add",
-                      "path": "/spec/template/spec/containers/0/env/-",
-                      "value": {
-                          "name": "NODE_EXTRA_CA_CERTS",
-                          "value": "/ingress-cert/ca.crt"
-                      }
-                  },
-                  {
-                      "op": "add",
-                      "path": "/spec/template/spec/containers/0/volumeMounts/-",
-                      "value": {
-                          "name": "kube-root-ca",
-                          "mountPath": "/ingress-cert"
-                      }
-                  },
-                  {
-                      "op": "add",
-                      "path": "/spec/template/spec/volumes/-",
-                      "value": {
-                          "name": "kube-root-ca",
-                          "configMap": {
-                              "name": "kube-root-ca.crt",
-                              "defaultMode": 420
-                          }
-                      }
-                  }
-              ]
-              EOF
+              # Update env var.
+              if [ "$(yq '.spec.template.spec.containers[0].env[] | select(.name == "NODE_EXTRA_CA_CERTS") | length' "$DEPLOYMENT")" == "2" ]; then
+                  YQ_EXPRESSION='
+              (
+                  .spec.template.spec.containers[].env[] |
+                  select(.name == "NODE_EXTRA_CA_CERTS") | .value
+              ) = "/ingress-cert/ca.crt"
+              '
+              else
+                  YQ_EXPRESSION='.spec.template.spec.containers[0].env += {"name": "NODE_EXTRA_CA_CERTS", "value": "/ingress-cert/ca.crt"}'
+              fi
+              yq --inplace "$YQ_EXPRESSION" "$DEPLOYMENT"
               echo -n "."
-              oc patch deployment/developer-hub --namespace "$NAMESPACE" --type=json --patch-file="$PATCH" >/dev/null
+              # Update volume mount
+              if [ "$(yq '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "kube-root-ca") | length' "$DEPLOYMENT")" == "2" ]; then
+                  YQ_EXPRESSION='
+              (
+                  .spec.template.spec.containers[].volumeMounts[] |
+                  select(.name == "kube-root-ca") | .mountPath
+              ) = "/ingress-cert"
+              '
+              else
+                  YQ_EXPRESSION='.spec.template.spec.containers[0].volumeMounts += {"name": "kube-root-ca", "mountPath": "/ingress-cert"}'
+              fi
+              yq --inplace "$YQ_EXPRESSION" "$DEPLOYMENT"
+              echo -n "."
+              # Update volume
+              if [ "$(yq '.spec.template.spec.volumes[] | select(.name == "kube-root-ca") | length' "$DEPLOYMENT")" == "2" ]; then
+                  YQ_EXPRESSION='
+              (
+                  .spec.template.spec.volumes[] |
+                  select(.name == "kube-root-ca") | .configMap
+              ) = {"name": "kube-root-ca.crt", "defaultMode": 420}
+              '
+              else
+                  YQ_EXPRESSION='.spec.template.spec.volumes += {"name": "kube-root-ca", "configMap": {"name": "kube-root-ca.crt", "defaultMode": 420}}'
+              fi
+              yq --inplace "$YQ_EXPRESSION" "$DEPLOYMENT"
+              echo -n "."
+              oc apply -f "$DEPLOYMENT" >/dev/null
               echo "OK"
               
         


### PR DESCRIPTION
Once TLS had been configured once, the process was failing because it did not account for the existing configuration. Since 'oc patch' does not seem great to handle this scenario, 'yq' is used to set/update the values.