### PR TITLE
Fix the transparency.url in chains-config

### DIFF
--- a/templates/openshift-pipelines/includes/_tekton-config.tpl
+++ b/templates/openshift-pipelines/includes/_tekton-config.tpl
@@ -16,7 +16,7 @@
       "artifacts.taskrun.format": "in-toto",
       "artifacts.taskrun.storage": "oci",
       "transparency.enabled": "true",
-      "transparency.url": "http://rekor-server.rekor.svc"
+      "transparency.url": "http://rekor-server.{{.Release.Namespace}}.svc"
     }
   }
 }


### PR DESCRIPTION
We deploy Rekor in the rhtap namespace, not in the rekor namespace.