### PR TITLE
RHTAPBUGS-1149: Expose MinIO PVC Size

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -230,6 +230,9 @@ trusted-profile-analyzer:
       enabled: false
     containerSecurityContext:
       enabled: false
+    persistence:
+      # MinIO PVC size.
+      size: 5Gi
   # Bitnami's Keycloak IAM.
   keycloak:
     enabled: true


### PR DESCRIPTION
Creating a `5Gi` MinIO PVC by default.