### PR TITLE
Fix hardcoded namespace issue

### DIFF
--- a/templates/developer-hub/includes/configure/_configure_tls.tpl
+++ b/templates/developer-hub/includes/configure/_configure_tls.tpl
@@ -10,7 +10,7 @@ done
 echo "OK"
 
 DEPLOYMENT="/tmp/deployment.yaml"
-oc get deployment/developer-hub --namespace "rhtap" -o yaml >"$DEPLOYMENT"
+oc get deployment/developer-hub --namespace "$NAMESPACE" -o yaml >"$DEPLOYMENT"
 
 echo -n "* Configure TLS:"
 # Update env var.

--- a/test/data/helm-chart/template.yaml
+++ b/test/data/helm-chart/template.yaml
@@ -426,7 +426,7 @@ spec:
               echo "OK"
               
               DEPLOYMENT="/tmp/deployment.yaml"
-              oc get deployment/developer-hub --namespace "rhtap" -o yaml >"$DEPLOYMENT"
+              oc get deployment/developer-hub --namespace "$NAMESPACE" -o yaml >"$DEPLOYMENT"
               
               echo -n "* Configure TLS:"
               # Update env var.


### PR DESCRIPTION
Install would fail if a namespace other than 'rhtap' was specified.