### PR TITLE
Fix issue with app namespaces configuration

### DIFF
--- a/templates/namespace/developer/configure.yaml
+++ b/templates/namespace/developer/configure.yaml
@@ -1,12 +1,19 @@
 {{ define "rhtap.namespace.developer.configure" }}
-NAMESPACE_LIST=(
+DEV_NAMESPACE_LIST=(
 {{range (index .Values "trusted-application-pipeline" "namespaces")}} {{printf "%s-development" . | quote}} {{printf "%s-stage" . | quote}} {{printf "%s-prod" . | quote}}
 {{end}}
 )
 
-for NAMESPACE in "${NAMESPACE_LIST[@]}"; do
-  echo -n "* Configuring '$NAMESPACE' namespace: "
-  cat << EOF | sed "s|^metadata:.*|\0\n  namespace: $NAMESPACE|" | kubectl create --filename - >/dev/null
+echo -n "* Waiting for resources: "
+while ! kubectl get tasks "$CHART-dev-namespace-setup" >/dev/null 2>&1; do
+  echo -n "_"
+  sleep 2
+done
+echo "OK"
+
+for DEV_NAMESPACE in "${DEV_NAMESPACE_LIST[@]}"; do
+  echo -n "* Configuring '$DEV_NAMESPACE' namespace: "
+  cat << EOF | sed "s|^metadata:.*|\0\n  namespace: $DEV_NAMESPACE|" | kubectl create --filename - >/dev/null
 {{include "rhtap.namespace.dev_setup_pipelinerun" .}}
 EOF
   echo "OK"

--- a/templates/namespace/includes/_configure.tpl
+++ b/templates/namespace/includes/_configure.tpl
@@ -14,6 +14,8 @@
 
       {{ include "rhtap.openshift-pipelines.wait" . | indent 6 }}
 
+      CHART="{{.Chart.Name}}"
+
       echo -n "* Configuring Tasks: "
       cat << EOF | kubectl apply -f - >/dev/null
       {{ include "rhtap.namespace.dev_setup_task" . | indent 8 }}

--- a/test/data/helm-chart/template.yaml
+++ b/test/data/helm-chart/template.yaml
@@ -843,6 +843,8 @@ spec:
               echo "OK"
               
         
+              CHART="rhtap"
+        
               echo -n "* Configuring Tasks: "
               cat << EOF | kubectl apply -f - >/dev/null
                       
@@ -1027,14 +1029,21 @@ spec:
         
             
                     
-              NAMESPACE_LIST=(
+              DEV_NAMESPACE_LIST=(
                "rhtap-app-development" "rhtap-app-stage" "rhtap-app-prod"
               
               )
               
-              for NAMESPACE in "${NAMESPACE_LIST[@]}"; do
-                echo -n "* Configuring '$NAMESPACE' namespace: "
-                cat << EOF | sed "s|^metadata:.*|\0\n  namespace: $NAMESPACE|" | kubectl create --filename - >/dev/null
+              echo -n "* Waiting for resources: "
+              while ! kubectl get tasks "$CHART-dev-namespace-setup" >/dev/null 2>&1; do
+                echo -n "_"
+                sleep 2
+              done
+              echo "OK"
+              
+              for DEV_NAMESPACE in "${DEV_NAMESPACE_LIST[@]}"; do
+                echo -n "* Configuring '$DEV_NAMESPACE' namespace: "
+                cat << EOF | sed "s|^metadata:.*|\0\n  namespace: $DEV_NAMESPACE|" | kubectl create --filename - >/dev/null
               
               apiVersion: tekton.dev/v1
               kind: PipelineRun


### PR DESCRIPTION
In [RHTAPBUGS-1168](https://issues.redhat.com//browse/RHTAPBUGS-1168) a user reported that the Pipelines to configure the namespaces sometime failed. The log extract seemed to show that the failure was because a task was not available yet. Therefore a safeguard has been added to make sure the referenced task is available before creating the pipelines.