### PR TITLE
fix issue with redeployment creating namespace

### DIFF
--- a/templates/namespace/developer/configure.yaml
+++ b/templates/namespace/developer/configure.yaml
@@ -13,7 +13,7 @@ echo "OK"
 
 for DEV_NAMESPACE in "${DEV_NAMESPACE_LIST[@]}"; do
   echo -n "* Creating '$DEV_NAMESPACE' namespace: "
-  kubectl create namespace "$DEV_NAMESPACE" >/dev/null
+  kubectl create namespace "$DEV_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
   echo -n "."
   kubectl annotate namespace "$DEV_NAMESPACE" "argocd.argoproj.io/managed-by=$NAMESPACE" >/dev/null
   echo "OK"


### PR DESCRIPTION
When namespace already exists, it just print out a warning .
```
* Creating 'rhtap-app-prod' namespace: + kubectl create namespace rhtap-app-prod --dry-run=client -o yaml
+ kubectl apply -f -
Warning: resource namespaces/rhtap-app-prod is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
```