### PR TITLE
Fix security issue in Pipelines As Code

### DIFF
--- a/templates/openshift-pipelines/includes/_tekton-config.tpl
+++ b/templates/openshift-pipelines/includes/_tekton-config.tpl
@@ -17,6 +17,15 @@
       "artifacts.taskrun.storage": "oci",
       "transparency.enabled": "true",
       "transparency.url": "http://rekor-server.{{.Release.Namespace}}.svc"
+    },
+    "platforms": {
+      "openshift": {
+        "pipelinesAsCode": {
+          "settings": {
+            "remember-ok-to-test": "false"
+          }
+        }
+      }
     }
   }
 }

--- a/test/data/helm-chart/template.yaml
+++ b/test/data/helm-chart/template.yaml
@@ -1221,6 +1221,15 @@ spec:
                       "artifacts.taskrun.storage": "oci",
                       "transparency.enabled": "true",
                       "transparency.url": "http://rekor-server.rhtap.svc"
+                    },
+                    "platforms": {
+                      "openshift": {
+                        "pipelinesAsCode": {
+                          "settings": {
+                            "remember-ok-to-test": "false"
+                          }
+                        }
+                      }
                     }
                   }
                 }


### PR DESCRIPTION
An attacker could submit a harmless PR, get the required 'ok-to-test' to have the tekton pipelines executed, and then modify the PR to change the content of the test pipelines.
Since the unreviewed pipeline would run by default, the attacker could use it to gain access to data or resources they should not have access to.