### PR TITLE
Fix certify command

### DIFF
--- a/bin/make.sh
+++ b/bin/make.sh
@@ -163,8 +163,8 @@ certify() {
     --namespace "$NAMESPACE" \
     --set chart-testing.release="$APP_NAME" \
     --set profile.vendorType=redhat \
-    "/workspace/$HELM_REPOSITORY/$CHART_TGZ" |
-    yq '.results |= sort_by(.check)' >"$CERTIFICATION_DIR/report.$(date +%Y%m%d-%H%M%S).yaml"
+    "/workspace/$HELM_REPOSITORY/$CHART_TGZ" >"$CERTIFICATION_DIR/report.yaml"
+  yq '.results |= sort_by(.check)' "$CERTIFICATION_DIR/report.yaml" >"$CERTIFICATION_DIR/report.$(date +%Y%m%d-%H%M%S).yaml"
 }
 
 delete() {


### PR DESCRIPTION
Sorting the report is useful to use diff to compare the results of multiple runs. However, sorting is considered  a modification to the report and invalidates its digest.

The process is modified to produce 2 files:
* report.yaml: original report that can be submitted.
* report.$date.yaml: sorted file used for diffs.