### PR TITLE
Revert 'Pin DH version to 1.1.x'

### DIFF
--- a/templates/developer-hub/includes/_configure.tpl
+++ b/templates/developer-hub/includes/_configure.tpl
@@ -109,7 +109,6 @@
         --devel \
         --namespace=${NAMESPACE} \
         --values="$HELM_VALUES" \
-        --version=~1.1 \
         redhat-developer-hub \
         developer-hub/redhat-developer-hub >/dev/null; then
         echo "ERROR while installing chart!"

--- a/test/data/helm-chart/template.yaml
+++ b/test/data/helm-chart/template.yaml
@@ -401,7 +401,6 @@ spec:
                 --devel \
                 --namespace=${NAMESPACE} \
                 --values="$HELM_VALUES" \
-                --version=~1.1 \
                 redhat-developer-hub \
                 developer-hub/redhat-developer-hub >/dev/null; then
                 echo "ERROR while installing chart!"
@@ -1376,19 +1375,21 @@ spec:
                     organizationName: ${FULCIO__ORG_NAME}
                   config:
                     OIDCIssuers:
-                      "${FULCIO__OIDC__URL}":
+                      - Issuer: "${FULCIO__OIDC__URL}"
                         ClientID: ${FULCIO__OIDC__CLIENT_ID}
                         IssuerURL: "${FULCIO__OIDC__URL}"
                         Type: ${FULCIO__OIDC__TYPE}
                   externalAccess:
                     enabled: true
-                  monitoring: false
+                  monitoring:
+                    enabled: false
                 rekor:
                   externalAccess:
                     enabled: true
                   signer:
                     kms: secret
-                  monitoring: false
+                  monitoring:
+                    enabled: false
                 trillian:
                   database:
                     create: true


### PR DESCRIPTION
This change was untested and broke the install.
There's no need to pin the version on the main branch, as the helm repo that is targeted only contains a single version.