### PR TITLE
Migrate build-definitions redhat-appstudio images

### DIFF
--- a/chart/templates/openshift-pipelines/includes/_configure.tpl
+++ b/chart/templates/openshift-pipelines/includes/_configure.tpl
@@ -1,6 +1,6 @@
 {{ define "rhtap.pipelines.configure" }}
 - name: configure-pipelines
-  image: quay.io/redhat-appstudio/appstudio-utils:dbbdd82734232e6289e8fbae5b4c858481a7c057
+  image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
   workingDir: /tmp
   command:
     - /bin/bash

--- a/test/data/helm-chart/template.yaml
+++ b/test/data/helm-chart/template.yaml
@@ -1202,7 +1202,7 @@ spec:
         
                 
         - name: configure-pipelines
-          image: quay.io/redhat-appstudio/appstudio-utils:dbbdd82734232e6289e8fbae5b4c858481a7c057
+          image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
           workingDir: /tmp
           command:
             - /bin/bash


### PR DESCRIPTION
[STONEBLD-2339](https://issues.redhat.com//browse/STONEBLD-2339)

All the images built in build-definitions CI now get released to the
quay.io/konflux-ci organization.

Replace the relevant redhat-appstudio[-tekton-catalog] references in
this repo with konflux-ci[/tekton-catalog] references.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
