### PR TITLE
Fix tpa authenticator and rhdh blank page issue

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -102,6 +102,8 @@ trusted-application-pipeline:
   namespaces:
     - rhtap-app
 trusted-profile-analyzer:
+  authenticator:
+    type: keycloak
   bombastic:
     bucket: bombastic
     topics:

--- a/test/data/helm-chart/template.yaml
+++ b/test/data/helm-chart/template.yaml
@@ -284,7 +284,7 @@ spec:
               helm repo add developer-hub https://charts.openshift.io/ >/dev/null
               echo -n "."
               HELM_VALUES="/tmp/developer-hub-values.yaml"
-              helm show values --version=~1.1 developer-hub/redhat-developer-hub >"${HELM_VALUES}"
+              helm show values --version=~1.2 developer-hub/redhat-developer-hub >"${HELM_VALUES}"
         
               cat <<EOF > rhtap-values.yaml
               
@@ -1476,6 +1476,8 @@ spec:
           
               cat <<EOF >${TRUSTIFICATION_VALUES}
               ---
+              authenticator:
+                type: keycloak
               bombastic:
                 bucket: bombastic
                 topics:


### PR DESCRIPTION
rh-pre-commit.version: 2.1.0
rh-pre-commit.check-secrets: ENABLED

Fix tpa and rhdh installation.
